### PR TITLE
Fix Scala -> Java conversion logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,17 +14,24 @@ lazy val buildSettings = Seq(
 val datastaxVersion = "2.1.9"
 val catsVersion = "0.3.0"
 val shapelessVersion = "2.2.5"
+val scalacheckVersion = "1.12.5"
+
+lazy val coreDeps = Seq(
+  "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion,
+  "org.spire-math" %% "cats" % catsVersion,
+  "com.chuusai" %% "shapeless" % shapelessVersion,
+  "org.scodec" %% "scodec-bits" % "1.0.12"
+)
+
+lazy val testDeps = Seq(
+  "org.scalacheck" %% "scalacheck" % scalacheckVersion
+) map (_ % "test")
 
 lazy val baseSettings = Seq(
   scalacOptions ++= compilerOptions,
   scalacOptions in (Compile, console) := compilerOptions,
   scalacOptions in (Compile, test) := compilerOptions,
-  libraryDependencies ++= Seq(
-    "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion,
-    "org.spire-math" %% "cats" % catsVersion,
-    "com.chuusai" %% "shapeless" % shapelessVersion,
-    "org.scodec" %% "scodec-bits" % "1.0.12"
-  ),
+  libraryDependencies ++= coreDeps ++ testDeps,
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")

--- a/core/src/main/scala/agni/Agni.scala
+++ b/core/src/main/scala/agni/Agni.scala
@@ -59,7 +59,7 @@ object Agni extends Functions {
     }
 
   // TODO: improve implementation
-  private[agni] def convertToJava(any: Any): Object = any match {
+  val convertToJava: Any => Object = (any: Any) => any match {
     case a: Set[Any] => a.map(convertToJava).asJava: java.util.Set[Object]
     case a: Map[Any, Any] => a.map { case (k, v) => (convertToJava(k), convertToJava(v)) }.asJava: java.util.Map[Object, Object]
     case a: String => a
@@ -67,12 +67,12 @@ object Agni extends Functions {
     case a: Int => a: java.lang.Integer
     case a: Float => a: java.lang.Float
     case a: Double => a: java.lang.Double
-    case a: Object => a
     case a: BigDecimal => a.bigDecimal
     case a: BigInt => a.bigInteger
     case a: ByteVector => a.toArray
     case Some(a) => convertToJava(a)
     case None => null
+    case a: Object => a
     case a => new RuntimeException(s"uncaught class type ${a}")
   }
 

--- a/core/src/test/scala/agni/AgniSpec.scala
+++ b/core/src/test/scala/agni/AgniSpec.scala
@@ -1,0 +1,78 @@
+package agni
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop._
+import org.scalacheck._
+import scodec.bits.Arbitraries._
+import scodec.bits.ByteVector
+
+class AgniSpec extends Properties("Agni") {
+
+  property("convertStringToJava") = forAll { (a: String) =>
+    Agni.convertToJava(a) == a
+  }
+
+  property("convertLongToJava") = forAll { (a: Long) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.lang.Long] && converted == a
+  }
+
+  property("convertIntToJava") = forAll { (a: Int) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.lang.Integer] && a == converted
+  }
+
+  property("convertFloatToJava") = forAll { (a: Float) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.lang.Float] && a == converted
+  }
+
+  property("convertDoubleToJava") = forAll { (a: Double) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.lang.Double] && a == converted
+  }
+
+  property("convertBigDecimalToJava") = forAll { (a: BigDecimal) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.math.BigDecimal] && a.bigDecimal == converted
+  }
+
+  property("convertBigIntToJava") = forAll { (a: BigInt) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.math.BigInteger] && a.bigInteger == converted
+  }
+
+  property("convertByteVectorToJava") = forAll { (a: ByteVector) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[Array[Byte]] && java.util.Arrays.equals(converted.asInstanceOf[Array[Byte]], a.toArray)
+  }
+
+  implicit def arbSome[T](implicit a: Arbitrary[T]): Arbitrary[Some[T]] = Arbitrary {
+    for (e <- arbitrary[T]) yield Some(e)
+  }
+
+  property("convertSomeToJava") = forAll { (a: Some[BigInt]) =>
+    val converted = Agni.convertToJava(a)
+    converted.isInstanceOf[java.math.BigInteger] && a.get.bigInteger == converted
+  }
+
+  property("convertNoneToJava") = Prop {
+    val converted = Agni.convertToJava(None)
+    converted eq null
+  }
+
+  case class X(a: String, b: Int)
+
+  def genX: Gen[X] = for {
+    a <- arbitrary[String]
+    b <- arbitrary[Int]
+  } yield X(a, b)
+
+  implicit def arbX: Arbitrary[X] = Arbitrary(genX)
+
+  property("convetCaseClass") = forAll { (x: X) =>
+    val converted = Agni.convertToJava(x)
+    converted == x
+  }
+
+}

--- a/core/src/test/scala/scodec/bits/Arbitraries.scala
+++ b/core/src/test/scala/scodec/bits/Arbitraries.scala
@@ -1,0 +1,111 @@
+package scodec.bits
+
+import org.scalacheck.{ Arbitrary, Gen, Shrink }
+import Arbitrary.arbitrary
+
+import java.nio.ByteBuffer
+
+// borrowed from scodec-bits' test code
+object Arbitraries {
+
+  val flatBytes = genBitVector(500, 7) // regular flat bit vectors
+  val balancedTrees = genConcatBits(genBitVector(2000, 7)) // balanced trees of concatenations
+  val splitVectors = genSplitBits(5000) // split bit vectors: b.take(m) ++ b.drop(m)
+  val concatSplitVectors = genConcatBits(genSplitBits(5000)) // concatenated split bit vectors
+
+  val chunk = Gen.oneOf(flatBytes, balancedTrees, splitVectors, concatSplitVectors)
+  val bitStreams = genBitStream(chunk, Gen.choose(0, 5)) // streams of chunks
+
+  // very deeply right nested - to check for SOE
+  val hugeBitStreams = genBitStream(
+    genBitVector(30, 7),
+    Gen.choose(1000, 5000)
+  )
+
+  implicit val shrinkBitVector: Shrink[BitVector] =
+    Shrink[BitVector] { b =>
+      if (b.nonEmpty)
+        Stream.iterate(b.take(b.size / 2))(b2 => b2.take(b2.size / 2)).takeWhile(_.nonEmpty) ++
+          Stream(BitVector.empty)
+      else Stream.empty
+    }
+
+  def genBitStream(g: Gen[BitVector], steps: Gen[Int]): Gen[BitVector] = for {
+    n <- steps
+    chunks <- Gen.listOfN(n, g)
+  } yield BitVector.unfold(chunks)(s => s.headOption.map((_, s.tail)))
+
+  def genBitVector(maxBytes: Int = 1024, maxAdditionalBits: Int = 7): Gen[BitVector] = for {
+    byteSize <- Gen.choose(0, maxBytes)
+    additionalBits <- Gen.choose(0, maxAdditionalBits)
+    size = byteSize * 8 + additionalBits
+    bytes <- Gen.listOfN((size + 7) / 8, Gen.choose(0, 255))
+  } yield BitVector(ByteVector(bytes: _*)).take(size.toLong)
+
+  def genSplitBits(maxSize: Long) = for {
+    n <- Gen.choose(0L, maxSize)
+    b <- genBitVector(15, 7)
+  } yield {
+    val m = if (b.nonEmpty) (n % b.size).abs else 0
+    b.take(m) ++ b.drop(m)
+  }
+
+  def genConcatBits(g: Gen[BitVector]) =
+    genBitVector(2000, 7).map { b =>
+      b.toIndexedSeq.foldLeft(BitVector.empty)(
+        (acc, high) => acc ++ BitVector.bit(high)
+      )
+    }
+
+  def standardByteVectors(maxSize: Int): Gen[ByteVector] = for {
+    size <- Gen.choose(0, maxSize)
+    bytes <- Gen.listOfN(size, Gen.choose(0, 255))
+  } yield ByteVector(bytes: _*)
+
+  val sliceByteVectors: Gen[ByteVector] = for {
+    bytes <- arbitrary[Array[Byte]]
+    toDrop <- Gen.choose(0, bytes.size)
+  } yield ByteVector.view(bytes).drop(toDrop.toInt)
+
+  def genSplitBytes(g: Gen[ByteVector]) = for {
+    b <- g
+    n <- Gen.choose(0, b.size + 1)
+  } yield {
+    b.take(n) ++ b.drop(n)
+  }
+
+  def genByteBufferVectors(maxSize: Int): Gen[ByteVector] = for {
+    size <- Gen.choose(0, maxSize)
+    bytes <- Gen.listOfN(size, Gen.choose(0, 255))
+  } yield ByteVector.view(ByteBuffer.wrap(bytes.map(_.toByte).toArray))
+
+  def genConcatBytes(g: Gen[ByteVector]) =
+    g.map { b => b.toIndexedSeq.foldLeft(ByteVector.empty)(_ :+ _) }
+
+  val genVeryLargeByteVectors: Gen[ByteVector] = for {
+    b <- Gen.choose(0, 255)
+  } yield ByteVector.fill(Int.MaxValue.toInt + 1)(b)
+
+  val byteVectors: Gen[ByteVector] = Gen.oneOf(
+    standardByteVectors(100),
+    genConcatBytes(standardByteVectors(100)),
+    sliceByteVectors,
+    genSplitBytes(sliceByteVectors),
+    genSplitBytes(genConcatBytes(standardByteVectors(500))),
+    genByteBufferVectors(100)
+  )
+
+  val bytesWithIndex = for {
+    b <- byteVectors
+    i <- Gen.choose(0L, (b.size + 1).toLong)
+  } yield (b, i)
+
+  implicit val arbitraryByteVectors: Arbitrary[ByteVector] = Arbitrary(byteVectors)
+
+  implicit val shrinkByteVector: Shrink[ByteVector] =
+    Shrink[ByteVector] { b =>
+      if (b.nonEmpty)
+        Stream.iterate(b.take(b.size / 2))(b2 => b2.take(b2.size / 2)).takeWhile(_.nonEmpty) ++ Stream(ByteVector.empty)
+      else Stream.empty
+    }
+}


### PR DESCRIPTION
Found bug in converting Scala value to Java value logic. In the pattern match in the logic, `case a: Object =>` pattern matches any objects : -(
