### PR TITLE
Change the type annotation for Action

### DIFF
--- a/core/src/main/scala/agni/Agni.scala
+++ b/core/src/main/scala/agni/Agni.scala
@@ -17,7 +17,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, A] =
     withSession[Future, A] { session =>
-      Future(Xor.right(a))
+      Future(a)
     }
 
   def execute[A](query: String)(
@@ -26,7 +26,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, Iterator[A]] =
     withSession[Future, Iterator[A]] { session =>
-      Future(Xor.catchOnly[Throwable](session.execute(query).iterator.asScala.map(RowDecoder[A])))
+      Future(session.execute(query).iterator.asScala.map(RowDecoder[A]))
     }
 
   def execute[A](stmt: Statement)(
@@ -35,7 +35,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, Iterator[A]] =
     withSession[Future, Iterator[A]] { session =>
-      Future(Xor.catchOnly[Throwable](session.execute(stmt).iterator.asScala.map(RowDecoder[A])))
+      Future(session.execute(stmt).iterator.asScala.map(RowDecoder[A]))
     }
 
   def batchOn(
@@ -43,7 +43,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, BatchStatement] =
     withSession[Future, BatchStatement] { _ =>
-      Future(Xor.right(new BatchStatement))
+      Future(new BatchStatement)
     }
 
   def prepare(query: String)(
@@ -51,7 +51,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, PreparedStatement] =
     withSession[Future, PreparedStatement] { session =>
-      Future(Xor.catchOnly[Throwable](queryCache.getOrElseUpdate(query, session.prepare(query))))
+      Future(queryCache.getOrElseUpdate(query, session.prepare(query)))
     }
 
   def bind(bstmt: BatchStatement, pstmt: PreparedStatement, ps: Any*)(
@@ -59,7 +59,7 @@ object Agni extends Functions {
     ctx: ExecutionContext
   ): Action[Future, Unit] =
     withSession[Future, Unit] { session =>
-      Future(Xor.catchOnly[Throwable](bstmt.add(pstmt.bind(ps.map(convertToJava): _*))))
+      Future(bstmt.add(pstmt.bind(ps.map(convertToJava): _*)))
     }
 
   // TODO: improve implementation

--- a/core/src/main/scala/agni/Functions.scala
+++ b/core/src/main/scala/agni/Functions.scala
@@ -4,6 +4,5 @@ import com.datastax.driver.core.Session
 import cats.data.{ Xor, Kleisli }
 
 trait Functions {
-  def withSession[F[_], A](f: Session => F[Xor[Throwable, A]]): Action[F, A] =
-    Kleisli.function[Lambda[a => F[Xor[Throwable, a]]], Session, A](f)
+  def withSession[F[_], A](f: Session => F[A]): Action[F, A] = Action(f)
 }

--- a/core/src/main/scala/agni/package.scala
+++ b/core/src/main/scala/agni/package.scala
@@ -1,23 +1,9 @@
-import cats.FlatMap
-import cats.data.{ Xor, Kleisli }
-import cats.implicits._
+import cats.data.Kleisli
 import com.datastax.driver.core.Session
-
-import scala.concurrent.{ ExecutionContext, Future }
 
 package object agni {
 
-  type Action[F[_], U] = Kleisli[Lambda[a => F[Throwable Xor a]], Session, U]
-
-  implicit def resultFlatMap(implicit ec: ExecutionContext) = new FlatMap[Lambda[a => Future[Throwable Xor a]]] {
-    override def flatMap[A, B](fa: Future[Throwable Xor A])(f: (A) => Future[Throwable Xor B]): Future[Throwable Xor B] = fa.flatMap {
-      case x @ Xor.Left(e) => Future(x)
-      case Xor.Right(v) => f(v)
-    }
-    override def map[A, B](fa: Future[Throwable Xor A])(f: (A) => B): Future[Throwable Xor B] = fa.map {
-      case x @ Xor.Left(e) => x
-      case Xor.Right(v) => f(v).right
-    }
-  }
+  type Action[F[_], A] = Kleisli[F, Session, A]
+  val Action = Kleisli
 
 }


### PR DESCRIPTION
`scala.concurrent.Future` has `MonadError` instance of cats. so we can get any error in `implicitly[MonadError[Future, Throwable]].attempt(future)`
