### PR TITLE
Use `MonadError` instead of `Future`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 lazy val root = project.in(file("."))
+  .settings(name := "agni")
   .settings(allSettings)
   .settings(noPublishSettings)
-  .aggregate(core, examples)
-  .dependsOn(core, examples)
+  .aggregate(core, `twitter-util`, examples)
+  .dependsOn(core, `twitter-util`, examples)
 
 lazy val allSettings = buildSettings ++ baseSettings ++ publishSettings ++ scalariformSettings
 
@@ -16,6 +17,7 @@ val catsVersion = "0.4.1"
 val shapelessVersion = "2.3.0"
 val scalacheckVersion = "1.13.0"
 val scalatestVersion = "2.2.6"
+val catbirdVersion = "0.3.0"
 
 lazy val coreDeps = Seq(
   "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion classifier "shaded" excludeAll(
@@ -92,6 +94,21 @@ lazy val core = project.in(file("core"))
   )
   .settings(allSettings: _*)
 
+lazy val `twitter-util` = project.in(file("twitter-util"))
+  .settings(
+    description := "agni twitter-util",
+    moduleName := "agni-twitter-util",
+    name := "twitter-util"
+  )
+  .settings(allSettings: _*)
+  .settings(noPublishSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.catbird" %% "catbird-util" % catbirdVersion
+    )
+  )
+  .dependsOn(core)
+
 lazy val examples = project.in(file("examples"))
   .settings(
     description := "agni examples",
@@ -105,7 +122,7 @@ lazy val examples = project.in(file("examples"))
       "org.slf4j" % "slf4j-simple" % "1.7.13"
     )
   )
-  .dependsOn(core)
+  .dependsOn(core, `twitter-util`)
 
 lazy val compilerOptions = Seq(
   "-deprecation",

--- a/core/src/main/scala/agni/Functions.scala
+++ b/core/src/main/scala/agni/Functions.scala
@@ -1,8 +1,9 @@
 package agni
 
+import cats.data.Kleisli
 import com.datastax.driver.core.Session
-import cats.data.{ Xor, Kleisli }
 
-trait Functions {
-  def withSession[F[_], A](f: Session => F[A]): Action[F, A] = Action(f)
+trait Functions[F[_]] {
+  type Action[A] = Kleisli[F, Session, A]
+  def withSession[A](f: Session => F[A]): Action[A] = Kleisli(f)
 }

--- a/core/src/main/scala/agni/package.scala
+++ b/core/src/main/scala/agni/package.scala
@@ -1,9 +1,1 @@
-import cats.data.Kleisli
-import com.datastax.driver.core.Session
-
-package object agni {
-
-  type Action[F[_], A] = Kleisli[F, Session, A]
-  val Action = Kleisli
-
-}
+package object agni

--- a/core/src/main/scala/agni/std/Future.scala
+++ b/core/src/main/scala/agni/std/Future.scala
@@ -1,0 +1,11 @@
+package agni.std
+
+import agni.Agni
+import cats.MonadError
+import cats.std.future._
+
+import scala.concurrent.{ ExecutionContext, Future => SFuture }
+
+object Future extends Agni[SFuture, Throwable] {
+  implicit def scalaFutureMonadError(implicit EC: ExecutionContext) = MonadError[SFuture, Throwable]
+}

--- a/core/src/main/scala/agni/std/package.scala
+++ b/core/src/main/scala/agni/std/package.scala
@@ -1,0 +1,5 @@
+package agni
+
+package object std {
+
+}

--- a/core/src/test/scala/agni/AgniSpec.scala
+++ b/core/src/test/scala/agni/AgniSpec.scala
@@ -2,6 +2,7 @@ package agni
 
 import java.util
 
+import cats.Id
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop._
 import org.scalacheck._
@@ -9,6 +10,8 @@ import scodec.bits.Arbitraries._
 import scodec.bits.ByteVector
 
 class AgniSpec extends Properties("Agni") {
+
+  object Agni extends Agni[Id, Exception]
 
   property("convertStringToJava") = forAll { (a: String) =>
     Agni.convertToJava(a) == a

--- a/examples/src/main/scala/codec.scala
+++ b/examples/src/main/scala/codec.scala
@@ -1,0 +1,35 @@
+import java.nio.ByteBuffer
+
+import com.datastax.driver.core._
+
+object codec {
+
+  class LongToObjectCodec extends TypeCodec[Object](DataType.bigint(), classOf[Object]) {
+    def serialize(t: Object, protocolVersion: ProtocolVersion): ByteBuffer =
+      TypeCodec.bigint().serialize(
+        t.asInstanceOf[java.lang.Long],
+        protocolVersion
+      )
+    def parse(s: String): Object = s.toLong.asInstanceOf[Object]
+    def format(t: Object): String = t.toString
+    def deserialize(bytes: ByteBuffer, protocolVersion: ProtocolVersion): Object = {
+      val i = TypeCodec.bigint().deserialize(bytes, protocolVersion)
+      if (i == null) null else i.asInstanceOf[Object]
+    }
+  }
+
+  class AsciiToObjectCodec extends TypeCodec[Object](DataType.ascii(), classOf[Object]) {
+    def serialize(t: Object, protocolVersion: ProtocolVersion): ByteBuffer =
+      TypeCodec.ascii().serialize(
+        t.asInstanceOf[java.lang.String],
+        protocolVersion
+      )
+    def parse(s: String): Object = s.toLong.asInstanceOf[Object]
+    def format(t: Object): String = t.toString
+    def deserialize(bytes: ByteBuffer, protocolVersion: ProtocolVersion): Object = {
+      val i = TypeCodec.ascii().deserialize(bytes, protocolVersion)
+      if (i == null) null else i.asInstanceOf[Object]
+    }
+  }
+
+}

--- a/twitter-util/src/main/scala/agni/twitter/util/Future.scala
+++ b/twitter-util/src/main/scala/agni/twitter/util/Future.scala
@@ -1,0 +1,10 @@
+package agni.twitter.util
+
+import agni._
+import cats.MonadError
+import com.twitter.util.{ Future => TFuture }
+import io.catbird.util.futureInstance
+
+object Future extends Agni[TFuture, Throwable] {
+  implicit val twitterFutureMonadError = MonadError[TFuture, Throwable]
+}

--- a/twitter-util/src/main/scala/agni/twitter/util/Try.scala
+++ b/twitter-util/src/main/scala/agni/twitter/util/Try.scala
@@ -1,0 +1,10 @@
+package agni.twitter.util
+
+import agni._
+import cats.MonadError
+import com.twitter.util.{ Try => TTry }
+import io.catbird.util.tryInstance
+
+object Try extends Agni[TTry, Throwable] {
+  implicit val twitterTryMonadError = MonadError[TTry, Throwable]
+}


### PR DESCRIPTION
This PR is to avoid the dependence of `scala.concurrent.Future` from `core` module.
