### PR TITLE
Use `exclude` instead of `excludeAll` in dependency declaration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,11 @@ lazy val coreDeps = Seq(
   "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion classifier "shaded" excludeAll(
     ExclusionRule(organization = "io.netty")
   ) withSources,
+  "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion classifier "shaded" exclude(
+    "io.netty", "netty-handler"
+  ) exclude(
+    "io.netty", "netty-transport-native-epoll"
+  ) withSources,
   "org.typelevel" %% "cats" % catsVersion,
   "com.chuusai" %% "shapeless" % shapelessVersion,
   "org.scodec" %% "scodec-bits" % "1.1.0"


### PR DESCRIPTION
As [written in sbt's official document](http://www.scala-sbt.org/0.13/docs/Library-Management.html#Exclude+Transitive+Dependencies), dependency exclusion using `excludeAll` does not make any effect on generated pom. So fixed build.sbt to use `exclude` instead of `excludeAll`.
