### PR TITLE
Stop using the shaded jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val buildSettings = Seq(
   scalaVersion := "2.11.8"
 )
 
-val datastaxVersion = "3.0.3"
+val datastaxVersion = "3.1.0"
 val catsVersion = "0.4.1"
 val shapelessVersion = "2.3.1"
 val scalacheckVersion = "1.13.2"
@@ -20,18 +20,11 @@ val scalatestVersion = "2.2.6"
 val catbirdVersion = "0.3.0"
 
 lazy val coreDeps = Seq(
-  "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion classifier "shaded" excludeAll(
-    ExclusionRule(organization = "io.netty")
-  ) withSources,
-  "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion classifier "shaded" exclude(
-    "io.netty", "netty-handler"
-  ) exclude(
-    "io.netty", "netty-transport-native-epoll"
-  ) withSources,
+  "com.datastax.cassandra" % "cassandra-driver-core" % datastaxVersion,
   "org.typelevel" %% "cats" % catsVersion,
   "com.chuusai" %% "shapeless" % shapelessVersion,
   "org.scodec" %% "scodec-bits" % "1.1.0"
-)
+) map (_.withSources)
 
 lazy val testDeps = Seq(
   "org.scalacheck" %% "scalacheck" % scalacheckVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.12


### PR DESCRIPTION
The `shaded.jar` is not necessary to us. Therefore, to stop the use.
