### PR TITLE
👍 Improve PreparedStatment cache using google guava

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
 
-val datastaxVersion = "3.1.4"
+val datastaxVersion = "3.2.0"
 val catsVersion = "0.9.0"
 val shapelessVersion = "2.3.2"
 val scalacheckVersion = "1.13.5"
@@ -115,7 +115,9 @@ lazy val benchmarks = project.in(file("benchmarks"))
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.12.1"),
     libraryDependencies ++= coreDeps ++ Seq(
-      "io.catbird" %% "catbird-util" % catbirdVersion
+      "io.catbird" %% "catbird-util" % catbirdVersion,
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.4.0",
+      "com.github.ben-manes.caffeine" % "guava" % "2.4.0"
     )
   )
   .enablePlugins(JmhPlugin)
@@ -130,7 +132,8 @@ lazy val examples = project.in(file("examples"))
     scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.12.1"),
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-simple" % "1.7.13"
+      "org.slf4j" % "slf4j-simple" % "1.7.13",
+      "org.scalatest" %% "scalatest" % scalatestVersion
     )
   )
   .settings(allSettings: _*)

--- a/core/src/main/scala/agni/GetPreparedStatement.scala
+++ b/core/src/main/scala/agni/GetPreparedStatement.scala
@@ -1,0 +1,8 @@
+package agni
+
+import com.datastax.driver.core.{ PreparedStatement, RegularStatement, Session }
+
+trait GetPreparedStatement {
+
+  protected def getPrepared(session: Session, stmt: RegularStatement): PreparedStatement
+}

--- a/core/src/main/scala/agni/cache/CachedPreparedStatement.scala
+++ b/core/src/main/scala/agni/cache/CachedPreparedStatement.scala
@@ -1,0 +1,13 @@
+package agni
+package cache
+
+import com.datastax.driver.core.{ PreparedStatement, RegularStatement, Session }
+
+trait CachedPreparedStatement[F[_, _]] extends GetPreparedStatement {
+
+  protected val cache: F[String, PreparedStatement]
+
+  override def getPrepared(ctx: Session, stmt: RegularStatement): PreparedStatement
+
+  protected def clear(): Unit
+}

--- a/core/src/main/scala/agni/cache/CachedPreparedStatementWithGuava.scala
+++ b/core/src/main/scala/agni/cache/CachedPreparedStatementWithGuava.scala
@@ -1,0 +1,19 @@
+package agni
+package cache
+
+import java.util.concurrent.Callable
+
+import com.datastax.driver.core.{ PreparedStatement, RegularStatement, Session }
+import com.google.common.cache.Cache
+
+trait CachedPreparedStatementWithGuava extends CachedPreparedStatement[Cache] {
+
+  protected val cache: Cache[String, PreparedStatement]
+
+  override def getPrepared(session: Session, stmt: RegularStatement): PreparedStatement =
+    cache.get(stmt.toString, new Callable[PreparedStatement] {
+      override def call(): PreparedStatement = session.prepare(stmt)
+    })
+
+  override def clear(): Unit = cache.cleanUp()
+}

--- a/core/src/main/scala/agni/cache/CachedPreparedStatementWithTrieMap.scala
+++ b/core/src/main/scala/agni/cache/CachedPreparedStatementWithTrieMap.scala
@@ -1,0 +1,16 @@
+package agni
+package cache
+
+import com.datastax.driver.core.{ PreparedStatement, RegularStatement, Session }
+
+import scala.collection.concurrent.TrieMap
+
+trait CachedPreparedStatementWithTrieMap extends CachedPreparedStatement[TrieMap] {
+
+  protected val cache: TrieMap[String, PreparedStatement]
+
+  override def getPrepared(session: Session, stmt: RegularStatement): PreparedStatement =
+    cache.getOrElseUpdate(stmt.toString, session.prepare(stmt))
+
+  override def clear(): Unit = cache.clear()
+}

--- a/core/src/main/scala/agni/cache/package.scala
+++ b/core/src/main/scala/agni/cache/package.scala
@@ -1,0 +1,30 @@
+package agni
+
+import com.datastax.driver.core.{ PreparedStatement, Session }
+import com.google.common.cache.{ Cache, CacheBuilder, CacheLoader, LoadingCache }
+
+import scala.collection.concurrent.TrieMap
+
+package object cache {
+
+  object loading {
+
+    def sizedCache(size: Long, session: Session): LoadingCache[String, PreparedStatement] =
+      CacheBuilder.newBuilder()
+        .maximumSize(size)
+        .build[String, PreparedStatement](new CacheLoader[String, PreparedStatement] {
+          override def load(key: String): PreparedStatement = session.prepare(key)
+        })
+  }
+
+  object default {
+
+    implicit lazy val cache: Cache[String, PreparedStatement] =
+      CacheBuilder.newBuilder().build[String, PreparedStatement]
+  }
+
+  object trie {
+
+    implicit lazy val cache: TrieMap[String, PreparedStatement] = TrieMap.empty
+  }
+}

--- a/core/src/main/scala/agni/std/Future.scala
+++ b/core/src/main/scala/agni/std/Future.scala
@@ -3,13 +3,18 @@ package std
 
 import java.util.concurrent.Executor
 
+import agni.cache.{ CachedPreparedStatement, CachedPreparedStatementWithGuava }
 import cats.instances.future._
-import com.datastax.driver.core.{ ResultSet, Statement }
+import com.datastax.driver.core.{ PreparedStatement, ResultSet, Statement }
+import com.google.common.cache.Cache
 import com.google.common.util.concurrent.{ FutureCallback, Futures }
 
 import scala.concurrent.{ ExecutionContext, Promise, Future => SFuture }
 
-abstract class Future(implicit ec: ExecutionContext) extends Agni[SFuture, Throwable] {
+abstract class Future(implicit ec: ExecutionContext, _cache: Cache[String, PreparedStatement])
+    extends Agni[SFuture, Throwable] with CachedPreparedStatementWithGuava {
+
+  override protected val cache: Cache[String, PreparedStatement] = _cache
 
   type P[A] = Promise[Iterator[Result[A]]]
 

--- a/core/src/main/scala/agni/std/Try.scala
+++ b/core/src/main/scala/agni/std/Try.scala
@@ -1,14 +1,15 @@
 package agni
-package twitter.util
+package std
 
 import agni.cache.CachedPreparedStatementWithGuava
+import cats.instances.try_._
 import com.datastax.driver.core.PreparedStatement
 import com.google.common.cache.Cache
-import com.twitter.util.{ Try => TTry }
-import io.catbird.util._
+
+import scala.util.{ Try => STry }
 
 abstract class Try(implicit _cache: Cache[String, PreparedStatement])
-    extends Agni[TTry, Throwable] with CachedPreparedStatementWithGuava {
+    extends Agni[STry, Throwable] with CachedPreparedStatementWithGuava {
 
-  protected val cache: Cache[String, PreparedStatement] = _cache
+  override protected val cache: Cache[String, PreparedStatement] = _cache
 }

--- a/twitter-util/src/main/scala/agni/twitter/util/Future.scala
+++ b/twitter-util/src/main/scala/agni/twitter/util/Future.scala
@@ -3,12 +3,17 @@ package twitter.util
 
 import java.util.concurrent.Executor
 
-import io.catbird.util._
-import com.datastax.driver.core.{ ResultSet, Statement }
+import agni.cache.CachedPreparedStatementWithGuava
+import com.datastax.driver.core.{ PreparedStatement, ResultSet, Statement }
+import com.google.common.cache.Cache
 import com.google.common.util.concurrent.{ FutureCallback, Futures }
 import com.twitter.util.{ Promise, Future => TFuture }
+import io.catbird.util._
 
-object Future extends Agni[TFuture, Throwable] {
+abstract class Future(implicit _cache: Cache[String, PreparedStatement])
+    extends Agni[TFuture, Throwable] with CachedPreparedStatementWithGuava {
+
+  override protected val cache: Cache[String, PreparedStatement] = _cache
 
   type P[A] = Promise[Iterator[Result[A]]]
 


### PR DESCRIPTION
At long last!

<details>
<summary><b>Benchmarks</b></summary>

## Machine Spec

- MacBook Pro
- CPU: 3.1 GHz Intel Core i7
- Memory: 16 GB 1867 MHz DDR3

## Using C* docker container

- Tag: 3.10

## Result

```
Using Guava:

[info] Benchmark                           Mode  Cnt     Score     Error  Units
[info] AgniAsyncBenchmark.three           thrpt   20  1239.729 ± 147.907  ops/s
[info] AgniSyncBenchmark.three            thrpt   20   719.348 ±  94.647  ops/s
[info] AgniTwitterAsyncBenchmark.three    thrpt   20  1467.115 ± 165.105  ops/s
[info] CasJavaDriverAsyncBenchmark.three  thrpt   20  1479.601 ± 165.486  ops/s

Using Caffeine Guava adapters:

[info] Benchmark                           Mode  Cnt     Score     Error  Units
[info] AgniAsyncBenchmark.three           thrpt   20  1343.371 ± 205.350  ops/s
[info] AgniSyncBenchmark.three            thrpt   20   769.760 ±  58.393  ops/s
[info] AgniTwitterAsyncBenchmark.three    thrpt   20  1502.602 ±  66.875  ops/s
[info] CasJavaDriverAsyncBenchmark.three  thrpt   20  1555.424 ±  70.327  ops/s
```

</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yanana/agni/48)
<!-- Reviewable:end -->
