### PR TITLE
🚀 Improve performance for the Monix integration

### DIFF
--- a/benchmarks/src/main/scala/benchmarks/io/CassandraClientBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmarks/io/CassandraClientBenchmark.scala
@@ -44,8 +44,7 @@ abstract class CassandraClientBenchmark {
     string_column: String,
     map_column: Map[Int, String],
     list_column: List[BigInt],
-    vector_column: Vector[Date]
-  )
+    vector_column: Vector[Date])
 
   type UserTuple = (UUID, String, Map[Int, String], List[BigInt], Vector[Date])
 
@@ -56,8 +55,7 @@ abstract class CassandraClientBenchmark {
   val users: List[User] = List(
     User(uuid1, "a", (1 to 10).map(i => (i, "$i")).toMap, (1 to 10).map(BigInt.apply).toList, (1 to 10).map(_ => Date.from(Instant.now)).toVector),
     User(uuid2, "b", (1 to 100).map(i => (i, "$i")).toMap, (1 to 100).map(BigInt.apply).toList, (1 to 100).map(_ => Date.from(Instant.now)).toVector),
-    User(uuid3, "c", (1 to 1000).map(i => (i, "$i")).toMap, (1 to 1000).map(BigInt.apply).toList, (1 to 1000).map(_ => Date.from(Instant.now)).toVector)
-  )
+    User(uuid3, "c", (1 to 1000).map(i => (i, "$i")).toMap, (1 to 1000).map(BigInt.apply).toList, (1 to 1000).map(_ => Date.from(Instant.now)).toVector))
 
   implicit def buildStatement(s: String): RegularStatement = new SimpleStatement(s)
 
@@ -372,8 +370,7 @@ class JavaDriverFutureBenchmark extends CassandraClientBenchmark {
             string_column = x.getString("string_column"),
             map_column = x.getMap[Integer, String]("map_column", classOf[Integer], classOf[String]).asScala.toMap.map { case (k, v) => (k: Int, v) },
             list_column = x.getList[BigInteger]("list_column", classOf[BigInteger]).asScala.map(BigInt.apply).toList,
-            vector_column = x.getList[Date]("vector_column", classOf[Date]).asScala.toVector
-          )
+            vector_column = x.getList[Date]("vector_column", classOf[Date]).asScala.toVector)
         })
       }
     })

--- a/core/src/main/scala/agni/Binder.scala
+++ b/core/src/main/scala/agni/Binder.scala
@@ -21,8 +21,7 @@ object Binder extends LowPriorityBinder with TupleBind {
     implicit
     K: Witness.Aux[K],
     H: Lazy[RowSerializer[H]],
-    T: Lazy[Binder[T]]
-  ): Binder[FieldType[K, H] :: T] =
+    T: Lazy[Binder[T]]): Binder[FieldType[K, H] :: T] =
     new Binder[FieldType[K, H] :: T] {
       override def apply(bound: BoundStatement, version: ProtocolVersion, xs: FieldType[K, H] :: T): Result[BoundStatement] =
         xs match {
@@ -44,8 +43,7 @@ trait LowPriorityBinder {
   implicit def bindCaseClass[A, R <: HList](
     implicit
     gen: LabelledGeneric.Aux[A, R],
-    bind: Lazy[Binder[R]]
-  ): Binder[A] =
+    bind: Lazy[Binder[R]]): Binder[A] =
     new Binder[A] {
       override def apply(bound: BoundStatement, version: ProtocolVersion, a: A): Result[BoundStatement] =
         bind.value.apply(bound, version, gen.to(a))
@@ -58,8 +56,7 @@ trait TupleBind {
   implicit def bindTuple2[A, B](
     implicit
     A: RowSerializer[A],
-    B: RowSerializer[B]
-  ) = new Binder[(A, B)] {
+    B: RowSerializer[B]) = new Binder[(A, B)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -70,8 +67,7 @@ trait TupleBind {
     implicit
     A: RowSerializer[A],
     B: RowSerializer[B],
-    C: RowSerializer[C]
-  ) = new Binder[(A, B, C)] {
+    C: RowSerializer[C]) = new Binder[(A, B, C)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -83,8 +79,7 @@ trait TupleBind {
     A: RowSerializer[A],
     B: RowSerializer[B],
     C: RowSerializer[C],
-    D: RowSerializer[D]
-  ) = new Binder[(A, B, C, D)] {
+    D: RowSerializer[D]) = new Binder[(A, B, C, D)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -98,8 +93,7 @@ trait TupleBind {
     B: RowSerializer[B],
     C: RowSerializer[C],
     D: RowSerializer[D],
-    E: RowSerializer[E]
-  ) = new Binder[(A, B, C, D, E)] {
+    E: RowSerializer[E]) = new Binder[(A, B, C, D, E)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -115,8 +109,7 @@ trait TupleBind {
     C: RowSerializer[C],
     D: RowSerializer[D],
     E: RowSerializer[E],
-    F: RowSerializer[F]
-  ) = new Binder[(A, B, C, D, E, F)] {
+    F: RowSerializer[F]) = new Binder[(A, B, C, D, E, F)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -134,8 +127,7 @@ trait TupleBind {
     D: RowSerializer[D],
     E: RowSerializer[E],
     F: RowSerializer[F],
-    G: RowSerializer[G]
-  ) = new Binder[(A, B, C, D, E, F, G)] {
+    G: RowSerializer[G]) = new Binder[(A, B, C, D, E, F, G)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -155,8 +147,7 @@ trait TupleBind {
     E: RowSerializer[E],
     F: RowSerializer[F],
     G: RowSerializer[G],
-    H: RowSerializer[H]
-  ) = new Binder[(A, B, C, D, E, F, G, H)] {
+    H: RowSerializer[H]) = new Binder[(A, B, C, D, E, F, G, H)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -178,8 +169,7 @@ trait TupleBind {
     F: RowSerializer[F],
     G: RowSerializer[G],
     H: RowSerializer[H],
-    I: RowSerializer[I]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I)] {
+    I: RowSerializer[I]) = new Binder[(A, B, C, D, E, F, G, H, I)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -203,8 +193,7 @@ trait TupleBind {
     G: RowSerializer[G],
     H: RowSerializer[H],
     I: RowSerializer[I],
-    J: RowSerializer[J]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J)] {
+    J: RowSerializer[J]) = new Binder[(A, B, C, D, E, F, G, H, I, J)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -230,8 +219,7 @@ trait TupleBind {
     H: RowSerializer[H],
     I: RowSerializer[I],
     J: RowSerializer[J],
-    K: RowSerializer[K]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K)] {
+    K: RowSerializer[K]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -259,8 +247,7 @@ trait TupleBind {
     I: RowSerializer[I],
     J: RowSerializer[J],
     K: RowSerializer[K],
-    L: RowSerializer[L]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L)] {
+    L: RowSerializer[L]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -290,8 +277,7 @@ trait TupleBind {
     J: RowSerializer[J],
     K: RowSerializer[K],
     L: RowSerializer[L],
-    M: RowSerializer[M]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] {
+    M: RowSerializer[M]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -323,8 +309,7 @@ trait TupleBind {
     K: RowSerializer[K],
     L: RowSerializer[L],
     M: RowSerializer[M],
-    N: RowSerializer[N]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] {
+    N: RowSerializer[N]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -358,8 +343,7 @@ trait TupleBind {
     L: RowSerializer[L],
     M: RowSerializer[M],
     N: RowSerializer[N],
-    O: RowSerializer[O]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] {
+    O: RowSerializer[O]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -395,8 +379,7 @@ trait TupleBind {
     M: RowSerializer[M],
     N: RowSerializer[N],
     O: RowSerializer[O],
-    P: RowSerializer[P]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] {
+    P: RowSerializer[P]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -434,8 +417,7 @@ trait TupleBind {
     N: RowSerializer[N],
     O: RowSerializer[O],
     P: RowSerializer[P],
-    Q: RowSerializer[Q]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] {
+    Q: RowSerializer[Q]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -475,8 +457,7 @@ trait TupleBind {
     O: RowSerializer[O],
     P: RowSerializer[P],
     Q: RowSerializer[Q],
-    R: RowSerializer[R]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] {
+    R: RowSerializer[R]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -518,8 +499,7 @@ trait TupleBind {
     P: RowSerializer[P],
     Q: RowSerializer[Q],
     R: RowSerializer[R],
-    S: RowSerializer[S]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] {
+    S: RowSerializer[S]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -563,8 +543,7 @@ trait TupleBind {
     Q: RowSerializer[Q],
     R: RowSerializer[R],
     S: RowSerializer[S],
-    T: RowSerializer[T]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] {
+    T: RowSerializer[T]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -610,8 +589,7 @@ trait TupleBind {
     R: RowSerializer[R],
     S: RowSerializer[S],
     T: RowSerializer[T],
-    U: RowSerializer[U]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] {
+    U: RowSerializer[U]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)
@@ -660,8 +638,7 @@ trait TupleBind {
     S: RowSerializer[S],
     T: RowSerializer[T],
     U: RowSerializer[U],
-    V: RowSerializer[V]
-  ) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] {
+    V: RowSerializer[V]) = new Binder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] {
     override def apply(bound: BoundStatement, version: ProtocolVersion, xs: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)): Result[BoundStatement] = for {
       _ <- A.apply(bound, 0, xs._1, version)
       _ <- B.apply(bound, 1, xs._2, version)

--- a/core/src/main/scala/agni/Deserializer.scala
+++ b/core/src/main/scala/agni/Deserializer.scala
@@ -128,8 +128,7 @@ object Deserializer {
     implicit
     K: Deserializer[K],
     V: Deserializer[V],
-    cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]
-  ): Deserializer[M[K, V]] = new Deserializer[M[K, V]] {
+    cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]): Deserializer[M[K, V]] = new Deserializer[M[K, V]] {
     override def apply(raw: ByteBuffer, version: ProtocolVersion): Result[M[K, V]] = {
       val builder = cbf.apply
       if (raw == null || !raw.hasRemaining)

--- a/core/src/main/scala/agni/Get.scala
+++ b/core/src/main/scala/agni/Get.scala
@@ -13,8 +13,7 @@ trait Get[A] {
   def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
     implicit
     F: MonadError[F, E],
-    ev: Throwable <:< E
-  ): F[A]
+    ev: Throwable <:< E): F[A]
 }
 
 object Get {
@@ -25,16 +24,14 @@ object Get {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: <:<[Throwable, E]
-    ): F[Unit] = F.pure(())
+      ev: <:<[Throwable, E]): F[Unit] = F.pure(())
   }
 
   implicit def getOneUnsafe[A](implicit A: RowDecoder[A]): Get[A] = new Get[A] {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: <:<[Throwable, E]
-    ): F[A] =
+      ev: <:<[Throwable, E]): F[A] =
       F.catchNonFatal(A(result.one, version).fold(throw _, identity))
   }
 
@@ -42,8 +39,7 @@ object Get {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: <:<[Throwable, E]
-    ): F[Option[A]] = {
+      ev: <:<[Throwable, E]): F[Option[A]] = {
       val row = result.one
       if (row == null) F.pure(none)
       else A(row, version).fold(F.raiseError(_), a => F.pure(a.some))
@@ -53,13 +49,11 @@ object Get {
   implicit def getCBF[A: RowDecoder, C[_]](
     implicit
     A: RowDecoder[A],
-    cbf: CanBuildFrom[Nothing, A, C[A]]
-  ): Get[C[A]] = new Get[C[A]] {
+    cbf: CanBuildFrom[Nothing, A, C[A]]): Get[C[A]] = new Get[C[A]] {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: <:<[Throwable, E]
-    ): F[C[A]] = {
+      ev: <:<[Throwable, E]): F[C[A]] = {
       val f = Foldable.iteratorFoldM[F, Row, mutable.Builder[A, C[A]]](result.iterator.asScala, cbf.apply) {
         case (b, a) => A(a, version).fold(F.raiseError(_), a => { b += a; F.pure(b) })
       }
@@ -71,8 +65,7 @@ object Get {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: Throwable <:< E
-    ): F[Iterator[Row]] =
+      ev: Throwable <:< E): F[Iterator[Row]] =
       F.catchNonFatal(result.iterator.asScala)
   }
 
@@ -80,8 +73,7 @@ object Get {
     override def apply[F[_], E](result: ResultSet, version: ProtocolVersion)(
       implicit
       F: MonadError[F, E],
-      ev: Throwable <:< E
-    ): F[java.util.stream.Stream[Row]] =
+      ev: Throwable <:< E): F[java.util.stream.Stream[Row]] =
       F.catchNonFatal(java.util.stream.StreamSupport.stream(result.spliterator(), false))
   }
 }

--- a/core/src/main/scala/agni/RowDecoder.scala
+++ b/core/src/main/scala/agni/RowDecoder.scala
@@ -30,8 +30,7 @@ object RowDecoder extends LowPriorityRowDecoder with TupleRowDecoder {
     implicit
     K: Witness.Aux[K],
     H: Lazy[RowDeserializer[H]],
-    T: Lazy[RowDecoder[T]]
-  ): RowDecoder[FieldType[K, H] :: T] =
+    T: Lazy[RowDecoder[T]]): RowDecoder[FieldType[K, H] :: T] =
     new RowDecoder[FieldType[K, H] :: T] {
       def apply(row: Row, version: ProtocolVersion): Result[FieldType[K, H] :: T] = for {
         h <- H.value.apply(row, K.value.name, version)
@@ -41,8 +40,7 @@ object RowDecoder extends LowPriorityRowDecoder with TupleRowDecoder {
 
   implicit def decodeSingleColumn[A](
     implicit
-    A: RowDeserializer[A]
-  ): RowDecoder[A] = new RowDecoder[A] {
+    A: RowDeserializer[A]): RowDecoder[A] = new RowDecoder[A] {
     def apply(row: Row, version: ProtocolVersion): Result[A] =
       A.apply(row, 0, version)
   }
@@ -53,8 +51,7 @@ trait LowPriorityRowDecoder {
   implicit def decodeCaseClass[A, R <: HList](
     implicit
     gen: LabelledGeneric.Aux[A, R],
-    decode: Lazy[RowDecoder[R]]
-  ): RowDecoder[A] =
+    decode: Lazy[RowDecoder[R]]): RowDecoder[A] =
     new RowDecoder[A] {
       def apply(s: Row, version: ProtocolVersion): Result[A] = decode.value(s, version) map (gen from)
     }
@@ -65,8 +62,7 @@ trait TupleRowDecoder {
   implicit def tuple2RowDecoder[A, B](
     implicit
     A: RowDeserializer[A],
-    B: RowDeserializer[B]
-  ): RowDecoder[(A, B)] =
+    B: RowDeserializer[B]): RowDecoder[(A, B)] =
     new RowDecoder[(A, B)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version)).tupled
@@ -76,8 +72,7 @@ trait TupleRowDecoder {
     implicit
     A: RowDeserializer[A],
     B: RowDeserializer[B],
-    C: RowDeserializer[C]
-  ): RowDecoder[(A, B, C)] =
+    C: RowDeserializer[C]): RowDecoder[(A, B, C)] =
     new RowDecoder[(A, B, C)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version)).tupled
@@ -88,8 +83,7 @@ trait TupleRowDecoder {
     A: RowDeserializer[A],
     B: RowDeserializer[B],
     C: RowDeserializer[C],
-    D: RowDeserializer[D]
-  ): RowDecoder[(A, B, C, D)] =
+    D: RowDeserializer[D]): RowDecoder[(A, B, C, D)] =
     new RowDecoder[(A, B, C, D)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version)).tupled
@@ -101,8 +95,7 @@ trait TupleRowDecoder {
     B: RowDeserializer[B],
     C: RowDeserializer[C],
     D: RowDeserializer[D],
-    E: RowDeserializer[E]
-  ): RowDecoder[(A, B, C, D, E)] =
+    E: RowDeserializer[E]): RowDecoder[(A, B, C, D, E)] =
     new RowDecoder[(A, B, C, D, E)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version)).tupled
@@ -115,8 +108,7 @@ trait TupleRowDecoder {
     C: RowDeserializer[C],
     D: RowDeserializer[D],
     E: RowDeserializer[E],
-    F: RowDeserializer[F]
-  ): RowDecoder[(A, B, C, D, E, F)] =
+    F: RowDeserializer[F]): RowDecoder[(A, B, C, D, E, F)] =
     new RowDecoder[(A, B, C, D, E, F)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version)).tupled
@@ -130,8 +122,7 @@ trait TupleRowDecoder {
     D: RowDeserializer[D],
     E: RowDeserializer[E],
     F: RowDeserializer[F],
-    G: RowDeserializer[G]
-  ): RowDecoder[(A, B, C, D, E, F, G)] =
+    G: RowDeserializer[G]): RowDecoder[(A, B, C, D, E, F, G)] =
     new RowDecoder[(A, B, C, D, E, F, G)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version)).tupled
@@ -146,8 +137,7 @@ trait TupleRowDecoder {
     E: RowDeserializer[E],
     F: RowDeserializer[F],
     G: RowDeserializer[G],
-    H: RowDeserializer[H]
-  ): RowDecoder[(A, B, C, D, E, F, G, H)] =
+    H: RowDeserializer[H]): RowDecoder[(A, B, C, D, E, F, G, H)] =
     new RowDecoder[(A, B, C, D, E, F, G, H)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version)).tupled
@@ -163,8 +153,7 @@ trait TupleRowDecoder {
     F: RowDeserializer[F],
     G: RowDeserializer[G],
     H: RowDeserializer[H],
-    I: RowDeserializer[I]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I)] =
+    I: RowDeserializer[I]): RowDecoder[(A, B, C, D, E, F, G, H, I)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version)).tupled
@@ -181,8 +170,7 @@ trait TupleRowDecoder {
     G: RowDeserializer[G],
     H: RowDeserializer[H],
     I: RowDeserializer[I],
-    J: RowDeserializer[J]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J)] =
+    J: RowDeserializer[J]): RowDecoder[(A, B, C, D, E, F, G, H, I, J)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version)).tupled
@@ -200,8 +188,7 @@ trait TupleRowDecoder {
     H: RowDeserializer[H],
     I: RowDeserializer[I],
     J: RowDeserializer[J],
-    K: RowDeserializer[K]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K)] =
+    K: RowDeserializer[K]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version)).tupled
@@ -220,8 +207,7 @@ trait TupleRowDecoder {
     I: RowDeserializer[I],
     J: RowDeserializer[J],
     K: RowDeserializer[K],
-    L: RowDeserializer[L]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L)] =
+    L: RowDeserializer[L]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version)).tupled
@@ -241,8 +227,7 @@ trait TupleRowDecoder {
     J: RowDeserializer[J],
     K: RowDeserializer[K],
     L: RowDeserializer[L],
-    M: RowDeserializer[M]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] {
+    M: RowDeserializer[M]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] = new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] {
     def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M)] =
       (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version)).tupled
   }
@@ -262,8 +247,7 @@ trait TupleRowDecoder {
     K: RowDeserializer[K],
     L: RowDeserializer[L],
     M: RowDeserializer[M],
-    N: RowDeserializer[N]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] {
+    N: RowDeserializer[N]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] = new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] {
     def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
       (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version)).tupled
   }
@@ -284,8 +268,7 @@ trait TupleRowDecoder {
     L: RowDeserializer[L],
     M: RowDeserializer[M],
     N: RowDeserializer[N],
-    O: RowDeserializer[O]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
+    O: RowDeserializer[O]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version)).tupled
@@ -308,8 +291,7 @@ trait TupleRowDecoder {
     M: RowDeserializer[M],
     N: RowDeserializer[N],
     O: RowDeserializer[O],
-    P: RowDeserializer[P]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
+    P: RowDeserializer[P]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version)).tupled
@@ -333,8 +315,7 @@ trait TupleRowDecoder {
     N: RowDeserializer[N],
     O: RowDeserializer[O],
     P: RowDeserializer[P],
-    Q: RowDeserializer[Q]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
+    Q: RowDeserializer[Q]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version)).tupled
@@ -359,8 +340,7 @@ trait TupleRowDecoder {
     O: RowDeserializer[O],
     P: RowDeserializer[P],
     Q: RowDeserializer[Q],
-    R: RowDeserializer[R]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    R: RowDeserializer[R]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version) |@| R.apply(row, 17, version)).tupled
@@ -386,8 +366,7 @@ trait TupleRowDecoder {
     P: RowDeserializer[P],
     Q: RowDeserializer[Q],
     R: RowDeserializer[R],
-    S: RowDeserializer[S]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    S: RowDeserializer[S]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version) |@| R.apply(row, 17, version) |@| S.apply(row, 18, version)).tupled
@@ -414,8 +393,7 @@ trait TupleRowDecoder {
     Q: RowDeserializer[Q],
     R: RowDeserializer[R],
     S: RowDeserializer[S],
-    T: RowDeserializer[T]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    T: RowDeserializer[T]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version) |@| R.apply(row, 17, version) |@| S.apply(row, 18, version) |@| T.apply(row, 19, version)).tupled
@@ -443,8 +421,7 @@ trait TupleRowDecoder {
     R: RowDeserializer[R],
     S: RowDeserializer[S],
     T: RowDeserializer[T],
-    U: RowDeserializer[U]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    U: RowDeserializer[U]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version) |@| R.apply(row, 17, version) |@| S.apply(row, 18, version) |@| T.apply(row, 19, version) |@| U.apply(row, 20, version)).tupled
@@ -473,8 +450,7 @@ trait TupleRowDecoder {
     S: RowDeserializer[S],
     T: RowDeserializer[T],
     U: RowDeserializer[U],
-    V: RowDeserializer[V]
-  ): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    V: RowDeserializer[V]): RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
     new RowDecoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] {
       def apply(row: Row, version: ProtocolVersion): Result[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
         (A.apply(row, 0, version) |@| B.apply(row, 1, version) |@| C.apply(row, 2, version) |@| D.apply(row, 3, version) |@| E.apply(row, 4, version) |@| F.apply(row, 5, version) |@| G.apply(row, 6, version) |@| H.apply(row, 7, version) |@| I.apply(row, 8, version) |@| J.apply(row, 9, version) |@| K.apply(row, 10, version) |@| L.apply(row, 11, version) |@| M.apply(row, 12, version) |@| N.apply(row, 13, version) |@| O.apply(row, 14, version) |@| P.apply(row, 15, version) |@| Q.apply(row, 16, version) |@| R.apply(row, 17, version) |@| S.apply(row, 18, version) |@| T.apply(row, 19, version) |@| U.apply(row, 20, version) |@| V.apply(row, 21, version)).tupled

--- a/core/src/main/scala/agni/Serializer.scala
+++ b/core/src/main/scala/agni/Serializer.scala
@@ -117,8 +117,7 @@ object Serializer {
   implicit def map[M[K, V] <: Map[K, V], K, V](
     implicit
     K: Serializer[K],
-    V: Serializer[V]
-  ): Serializer[M[K, V]] = new Serializer[M[K, V]] {
+    V: Serializer[V]): Serializer[M[K, V]] = new Serializer[M[K, V]] {
     override def apply(value: M[K, V], version: ProtocolVersion): Result[ByteBuffer] = {
       @tailrec def go(m: List[(K, V)], acc: mutable.ArrayBuilder[ByteBuffer]): Result[Array[ByteBuffer]] = m match {
         case Nil => acc.result().asRight
@@ -142,8 +141,7 @@ object Serializer {
   implicit def traversableOnce[A0, C[_]](
     implicit
     A: Serializer[A0],
-    is: IsTraversableOnce[C[A0]] { type A = A0 }
-  ): Serializer[C[A0]] =
+    is: IsTraversableOnce[C[A0]] { type A = A0 }): Serializer[C[A0]] =
     new Serializer[C[A0]] {
       override def apply(value: C[A0], version: ProtocolVersion): Result[ByteBuffer] = {
         if (value == null) Left(new NullPointerException) else {

--- a/core/src/main/scala/agni/std/Future.scala
+++ b/core/src/main/scala/agni/std/Future.scala
@@ -13,7 +13,7 @@ import com.google.common.util.concurrent.{ FutureCallback, Futures }
 import scala.concurrent.{ ExecutionContext, Promise, Future => SFuture }
 
 abstract class Future(implicit ec: ExecutionContext, _cache: Cache[String, PreparedStatement])
-    extends Agni[SFuture, Throwable] with CachedPreparedStatementWithGuava {
+  extends Agni[SFuture, Throwable] with CachedPreparedStatementWithGuava {
 
   override val F: MonadError[SFuture, Throwable] = catsStdInstancesForFuture
 

--- a/core/src/main/scala/agni/std/Try.scala
+++ b/core/src/main/scala/agni/std/Try.scala
@@ -10,7 +10,7 @@ import com.google.common.cache.Cache
 import scala.util.{ Try => STry }
 
 abstract class Try(implicit _cache: Cache[String, PreparedStatement])
-    extends Agni[STry, Throwable] with CachedPreparedStatementWithGuava {
+  extends Agni[STry, Throwable] with CachedPreparedStatementWithGuava {
 
   override val F: MonadError[STry, Throwable] = catsStdInstancesForTry
 

--- a/fs2/src/main/scala/agni/fs2/Task.scala
+++ b/fs2/src/main/scala/agni/fs2/Task.scala
@@ -15,7 +15,7 @@ import _root_.fs2.{ Strategy, Task => FTask }
 import scala.util.Try
 
 abstract class Task(implicit _cache: Cache[String, PreparedStatement])
-    extends Agni[FTask, Throwable] with CachedPreparedStatementWithGuava {
+  extends Agni[FTask, Throwable] with CachedPreparedStatementWithGuava {
 
   override implicit val F: MonadError[FTask, Throwable] =
     _root_.fs2.interop.cats.effectToMonadError
@@ -25,8 +25,7 @@ abstract class Task(implicit _cache: Cache[String, PreparedStatement])
   def getAsync[A: Get](stmt: Statement)(
     implicit
     strategy: Strategy,
-    ex: Executor
-  ): Action[A] =
+    ex: Executor): Action[A] =
     withSession { s =>
       FTask.async { cb =>
         val f = s.executeAsync(stmt)

--- a/twitter-util/src/main/scala/agni/twitter/util/Future.scala
+++ b/twitter-util/src/main/scala/agni/twitter/util/Future.scala
@@ -12,7 +12,7 @@ import com.twitter.util.{ Promise, Future => TFuture }
 import io.catbird.util._
 
 abstract class Future(implicit _cache: Cache[String, PreparedStatement])
-    extends Agni[TFuture, Throwable] with CachedPreparedStatementWithGuava {
+  extends Agni[TFuture, Throwable] with CachedPreparedStatementWithGuava {
 
   override implicit val F: MonadError[TFuture, Throwable] = twitterFutureInstance
 

--- a/twitter-util/src/main/scala/agni/twitter/util/Try.scala
+++ b/twitter-util/src/main/scala/agni/twitter/util/Try.scala
@@ -9,7 +9,7 @@ import com.twitter.util.{ Try => TTry }
 import io.catbird.util._
 
 abstract class Try(implicit _cache: Cache[String, PreparedStatement])
-    extends Agni[TTry, Throwable] with CachedPreparedStatementWithGuava {
+  extends Agni[TTry, Throwable] with CachedPreparedStatementWithGuava {
 
   override implicit val F: MonadError[TTry, Throwable] = twitterTryInstance
 


### PR DESCRIPTION
This PR slightly improvements performance for the `getAsync` method of the Monix integrations.

<details>
<summary>Benchmarks (before and after)</summary>

**Before**

```
[info] Benchmark                                                   Mode  Cnt        Score        Error   Units
[info] MonixTaskBenchmark.one                                     thrpt   10     1238.810 ±    115.783   ops/s
[info] MonixTaskBenchmark.one:·gc.alloc.rate                      thrpt   10       20.309 ±      5.365  MB/sec
[info] MonixTaskBenchmark.one:·gc.alloc.rate.norm                 thrpt   10    20826.804 ±   3263.842    B/op
[info] MonixTaskBenchmark.one:·gc.churn.PS_Eden_Space             thrpt   10       23.033 ±     19.764  MB/sec
[info] MonixTaskBenchmark.one:·gc.churn.PS_Eden_Space.norm        thrpt   10    24031.376 ±  20348.512    B/op
[info] MonixTaskBenchmark.one:·gc.churn.PS_Survivor_Space         thrpt   10        0.011 ±      0.038  MB/sec
[info] MonixTaskBenchmark.one:·gc.churn.PS_Survivor_Space.norm    thrpt   10       10.991 ±     37.195    B/op
[info] MonixTaskBenchmark.one:·gc.count                           thrpt   10        8.000               counts
[info] MonixTaskBenchmark.one:·gc.time                            thrpt   10       46.000                   ms
[info] MonixTaskBenchmark.three                                   thrpt   10      401.915 ±     21.572   ops/s
[info] MonixTaskBenchmark.three:·gc.alloc.rate                    thrpt   10      374.290 ±    105.591  MB/sec
[info] MonixTaskBenchmark.three:·gc.alloc.rate.norm               thrpt   10  1174860.667 ± 152574.780    B/op
[info] MonixTaskBenchmark.three:·gc.churn.PS_Eden_Space           thrpt   10      390.425 ±    112.535  MB/sec
[info] MonixTaskBenchmark.three:·gc.churn.PS_Eden_Space.norm      thrpt   10  1232678.045 ± 203309.184    B/op
[info] MonixTaskBenchmark.three:·gc.churn.PS_Survivor_Space       thrpt   10        0.157 ±      0.096  MB/sec
[info] MonixTaskBenchmark.three:·gc.churn.PS_Survivor_Space.norm  thrpt   10      525.915 ±    477.554    B/op
[info] MonixTaskBenchmark.three:·gc.count                         thrpt   10       56.000               counts
[info] MonixTaskBenchmark.three:·gc.time                          thrpt   10       81.000                   ms
```

**After**

```
[info] Benchmark                                                   Mode  Cnt        Score        Error   Units
[info] MonixTaskBenchmark.one                                     thrpt   10     1550.227 ±     63.135   ops/s
[info] MonixTaskBenchmark.one:·gc.alloc.rate                      thrpt   10       25.706 ±      7.809  MB/sec
[info] MonixTaskBenchmark.one:·gc.alloc.rate.norm                 thrpt   10    20846.435 ±   3251.766    B/op
[info] MonixTaskBenchmark.one:·gc.churn.PS_Eden_Space             thrpt   10       25.804 ±     21.158  MB/sec
[info] MonixTaskBenchmark.one:·gc.churn.PS_Eden_Space.norm        thrpt   10    20212.258 ±  16477.675    B/op
[info] MonixTaskBenchmark.one:·gc.churn.PS_Survivor_Space         thrpt   10        0.012 ±      0.031  MB/sec
[info] MonixTaskBenchmark.one:·gc.churn.PS_Survivor_Space.norm    thrpt   10        9.762 ±     23.946    B/op
[info] MonixTaskBenchmark.one:·gc.count                           thrpt   10        8.000               counts
[info] MonixTaskBenchmark.one:·gc.time                            thrpt   10       39.000                   ms
[info] MonixTaskBenchmark.three                                   thrpt   10      421.349 ±     26.664   ops/s
[info] MonixTaskBenchmark.three:·gc.alloc.rate                    thrpt   10      390.921 ±    109.727  MB/sec
[info] MonixTaskBenchmark.three:·gc.alloc.rate.norm               thrpt   10  1172252.940 ± 162208.430    B/op
[info] MonixTaskBenchmark.three:·gc.churn.PS_Eden_Space           thrpt   10      400.750 ±     99.587  MB/sec
[info] MonixTaskBenchmark.three:·gc.churn.PS_Eden_Space.norm      thrpt   10  1216783.951 ± 229042.414    B/op
[info] MonixTaskBenchmark.three:·gc.churn.PS_Survivor_Space       thrpt   10        0.138 ±      0.109  MB/sec
[info] MonixTaskBenchmark.three:·gc.churn.PS_Survivor_Space.norm  thrpt   10      426.011 ±    336.078    B/op
[info] MonixTaskBenchmark.three:·gc.count                         thrpt   10       57.000               counts
[info] MonixTaskBenchmark.three:·gc.time                          thrpt   10       84.000                   ms
```
</details>