### PR TITLE
🔥 Remove a Java Executor from `getAsync` of the std-future module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,6 +161,11 @@ lazy val benchmarks = project.in(file("benchmarks"))
       "co.fs2" %% "fs2-cats" % "0.3.0",
       "com.github.ben-manes.caffeine" % "caffeine" % "2.4.0",
       "com.github.ben-manes.caffeine" % "guava" % "2.4.0"
+    ),
+    scalacOptions ++= Seq(
+      "-opt:l:inline",
+      "-opt-inline-from:**",
+      "-opt-warnings"
     )
   )
   .enablePlugins(JmhPlugin)

--- a/core/src/test/scala/agni/cassandra/AResultSet.scala
+++ b/core/src/test/scala/agni/cassandra/AResultSet.scala
@@ -2,8 +2,7 @@ package agni.cassandra
 
 import java.util
 
-import com.datastax.driver.core.{ ColumnDefinitions, ExecutionInfo, ResultSet, Row }
-import com.google.common.util.concurrent.ListenableFuture
+import com.datastax.driver.core.Row
 
 import scala.collection.JavaConverters._
 


### PR DESCRIPTION
I tried to simplify the `agni.std.Future`'s getAsync.