### PR TITLE
Optimize performance of the case class derivation

### DIFF
--- a/benchmarks/src/test/scala/benchmarks/inMem/Base.scala
+++ b/benchmarks/src/test/scala/benchmarks/inMem/Base.scala
@@ -1,0 +1,19 @@
+package benchmarks.inMem
+
+import java.nio.ByteBuffer
+
+import benchmarks.inMem.cassandra.UndefinedRow
+import com.datastax.driver.core.{ ProtocolVersion, Row, TypeCodec }
+
+class Base {
+
+  val v: ProtocolVersion = ProtocolVersion.NEWEST_BETA
+
+  val row: Row = new UndefinedRow {
+    override def getString(i: Int): String = "fff"
+    override def getString(name: String): String = "ggg"
+
+    override def getBytesUnsafe(i: Int): ByteBuffer = TypeCodec.ascii().serialize("fff", v)
+    override def getBytesUnsafe(name: String): ByteBuffer = TypeCodec.ascii().serialize("ggg", v)
+  }
+}

--- a/benchmarks/src/test/scala/benchmarks/inMem/GetBenchmark.scala
+++ b/benchmarks/src/test/scala/benchmarks/inMem/GetBenchmark.scala
@@ -3,33 +3,50 @@ package benchmarks.inMem
 import java.util.concurrent.TimeUnit
 
 import agni.Get
-import benchmarks.inMem.cassandra.{ AResultSet, UndefinedRow }
+import benchmarks.inMem.cassandra.AResultSet
 import cats.instances.try_._
-import com.datastax.driver.core.{ ProtocolVersion, ResultSet }
+import com.datastax.driver.core.ResultSet
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 5, time = 3)
+@Warmup(iterations = 10, time = 5)
+@Measurement(iterations = 10, time = 10)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Fork(1)
+@Fork(2)
 class GetBenchmark {
-  private[this] val v = ProtocolVersion.NEWEST_BETA
-  private[this] val row = new UndefinedRow {
-    override def getString(i: Int): String = "fff"
-    override def getString(name: String): String = "ggg"
+  import GetBenchmark._
+
+  @Benchmark
+  def getRow100AsList(data: Data): List[C5] =
+    Get[List[C5]].apply[scala.util.Try, Throwable](data.row100, data.v).get
+
+  @Benchmark
+  def getRow1000AsList(data: Data): List[C5] =
+    Get[List[C5]].apply[scala.util.Try, Throwable](data.row1000, data.v).get
+
+  @Benchmark
+  def getRow5000AsList(data: Data): List[C5] =
+    Get[List[C5]].apply[scala.util.Try, Throwable](data.row5000, data.v).get
+
+  @Benchmark
+  def getRow100AsVector(data: Data): Vector[C5] =
+    Get[Vector[C5]].apply[scala.util.Try, Throwable](data.row100, data.v).get
+
+  @Benchmark
+  def getRow1000AsVector(data: Data): Vector[C5] =
+    Get[Vector[C5]].apply[scala.util.Try, Throwable](data.row1000, data.v).get
+
+  @Benchmark
+  def getRow5000AsVector(data: Data): Vector[C5] =
+    Get[Vector[C5]].apply[scala.util.Try, Throwable](data.row5000, data.v).get
+}
+
+object GetBenchmark {
+  @State(Scope.Benchmark)
+  class Data extends Base {
+    val row100: ResultSet = new AResultSet((1 to 100).map(_ => row))
+    val row1000: ResultSet = new AResultSet((1 to 1000).map(_ => row))
+    val row5000: ResultSet = new AResultSet((1 to 5000).map(_ => row))
   }
-
-  val row100: ResultSet = new AResultSet((1 to 100).map(_ => row))
-  val row1000: ResultSet = new AResultSet((1 to 1000).map(_ => row))
-  val row5000: ResultSet = new AResultSet((1 to 5000).map(_ => row))
-
-  @Benchmark def getRow100AsList: List[C5] = Get[List[C5]].apply[scala.util.Try, Throwable](row100, v).get
-  @Benchmark def getRow1000AsList: List[C5] = Get[List[C5]].apply[scala.util.Try, Throwable](row1000, v).get
-  @Benchmark def getRow5000AsList: List[C5] = Get[List[C5]].apply[scala.util.Try, Throwable](row5000, v).get
-
-  @Benchmark def getRow100AsVector: Vector[C5] = Get[Vector[C5]].apply[scala.util.Try, Throwable](row100, v).get
-  @Benchmark def getRow1000AsVector: Vector[C5] = Get[Vector[C5]].apply[scala.util.Try, Throwable](row1000, v).get
-  @Benchmark def getRow5000AsVector: Vector[C5] = Get[Vector[C5]].apply[scala.util.Try, Throwable](row5000, v).get
 }

--- a/benchmarks/src/test/scala/benchmarks/inMem/RowDecoderBenchmark.scala
+++ b/benchmarks/src/test/scala/benchmarks/inMem/RowDecoderBenchmark.scala
@@ -3,26 +3,66 @@ package benchmarks.inMem
 import java.util.concurrent.TimeUnit
 
 import agni.RowDecoder
-import benchmarks.inMem.cassandra.UndefinedRow
-import com.datastax.driver.core.ProtocolVersion
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 5, time = 3)
+@Warmup(iterations = 10, time = 5)
+@Measurement(iterations = 10, time = 10)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(1)
 class RowDecoderBenchmark {
-  private[this] val v = ProtocolVersion.NEWEST_BETA
-  private[this] val row = new UndefinedRow {
-    override def getString(i: Int): String = "fff"
-    override def getString(name: String): String = "ggg"
-  }
+  import RowDecoderBenchmark._
 
-  @Benchmark def stringTuple5: Either[Throwable, S5] = RowDecoder.apply[S5].apply(row, v)
-  @Benchmark def stringCaseClass5: Either[Throwable, C5] = RowDecoder.apply[C5].apply(row, v)
-  @Benchmark def stringTuple22: Either[Throwable, S22] = RowDecoder.apply[S22].apply(row, v)
-  @Benchmark def stringCaseClass22: Either[Throwable, C22] = RowDecoder.apply[C22].apply(row, v)
-  @Benchmark def stringCaseClass30: Either[Throwable, C30] = RowDecoder.apply[C30].apply(row, v)
+  @Benchmark
+  def stringTuple5(data: Data): Either[Throwable, S5] =
+    RowDecoder[S5].apply(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass5(data: Data): Either[Throwable, C5] =
+    RowDecoder[C5].apply(data.row, data.v)
+
+  @Benchmark
+  def stringTuple22(data: Data): Either[Throwable, S22] =
+    RowDecoder[S22].apply(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass22(data: Data): Either[Throwable, C22] =
+    RowDecoder[C22].apply(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass30(data: Data): Either[Throwable, C30] =
+    RowDecoder[C30].apply(data.row, data.v)
+
+  @Benchmark
+  def stringTuple5CachedDecoder(data: Data): Either[Throwable, S5] =
+    data.decodeS5(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass5CachedDecoder(data: Data): Either[Throwable, C5] =
+    data.decodeC5(data.row, data.v)
+
+  @Benchmark
+  def stringTuple22CachedDecoder(data: Data): Either[Throwable, S22] =
+    data.decodeS22(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass22CachedDecoder(data: Data): Either[Throwable, C22] =
+    data.decodeC22(data.row, data.v)
+
+  @Benchmark
+  def stringCaseClass30CachedDecoder(data: Data): Either[Throwable, C30] =
+    data.decodeC30(data.row, data.v)
+}
+
+object RowDecoderBenchmark {
+
+  @State(Scope.Benchmark)
+  class Data extends Base {
+    final val decodeS5: RowDecoder[S5] = RowDecoder[S5]
+    final val decodeS22: RowDecoder[S22] = RowDecoder[S22]
+    final val decodeC5: RowDecoder[C5] = RowDecoder[C5]
+    final val decodeC22: RowDecoder[C22] = RowDecoder[C22]
+    final val decodeC30: RowDecoder[C30] = RowDecoder[C30]
+  }
 }

--- a/benchmarks/src/test/scala/benchmarks/inMem/RowDecoderBenchmark.scala
+++ b/benchmarks/src/test/scala/benchmarks/inMem/RowDecoderBenchmark.scala
@@ -10,7 +10,7 @@ import org.openjdk.jmh.annotations._
 @Warmup(iterations = 10, time = 5)
 @Measurement(iterations = 10, time = 10)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Fork(1)
+@Fork(2)
 class RowDecoderBenchmark {
   import RowDecoderBenchmark._
 

--- a/core/src/main/scala/agni/Binder.scala
+++ b/core/src/main/scala/agni/Binder.scala
@@ -20,15 +20,15 @@ object Binder extends LowPriorityBinder with TupleBinder {
   implicit def bindLabelledHList[K <: Symbol, H, T <: HList](
     implicit
     K: Witness.Aux[K],
-    H: Lazy[RowSerializer[H]],
-    T: Lazy[Binder[T]]
+    H: RowSerializer[H],
+    T: Binder[T]
   ): Binder[FieldType[K, H] :: T] =
     new Binder[FieldType[K, H] :: T] {
       override def apply(bound: BoundStatement, version: ProtocolVersion, xs: FieldType[K, H] :: T): Result[BoundStatement] =
         xs match {
           case h :: t => for {
-            _ <- H.value.apply(bound, K.value.name, h, version)
-            r <- T.value.apply(bound, version, t)
+            _ <- H(bound, K.value.name, h, version)
+            r <- T(bound, version, t)
           } yield r
         }
     }


### PR DESCRIPTION
This change removes unnecessary wrapping to `shapeless.Lazy[T]`. Fortunately, performance has improved in no-cache case :)

Here is the decoding benchmark running a37e040559005311c92be5c01c36d2632a02f280:

```
[info] Benchmark                                                  Mode  Cnt       Score     Error  Units
[info] inMem.RowDecoderBenchmark.stringCaseClass30               thrpt   10  110357.451 ± 296.523  ops/s
[info] inMem.RowDecoderBenchmark.stringCaseClass30CachedDecoder  thrpt   10  167470.700 ± 280.239  ops/s
```

And here is running on e3afbbc5102c8b8c8d6fdac7222a65101a39c181:

```
[info] Benchmark                                                  Mode  Cnt       Score      Error  Units
[info] inMem.RowDecoderBenchmark.stringCaseClass30               thrpt   20  160026.525 ± 1646.298  ops/s
[info] inMem.RowDecoderBenchmark.stringCaseClass30CachedDecoder  thrpt   20  167366.145 ± 2927.827  ops/s
```
